### PR TITLE
hyprbars: add configurable edge, width and vertical offset for bars

### DIFF
--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -142,6 +142,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_align", Hyprlang::STRING{"center"});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_part_of_window", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_precedence_over_border", Hyprlang::INT{0});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_width", Hyprlang::INT{-1});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_edge", Hyprlang::STRING{"top"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_vertical_offset", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_buttons_alignment", Hyprlang::STRING{"right"});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_padding", Hyprlang::INT{7});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_button_padding", Hyprlang::INT{5});


### PR DESCRIPTION
### Motivation
- Make bar placement and sizing configurable so bars can be placed on top or bottom of windows and optionally given a fixed width or vertical offset.
- Preserve existing behavior by using `-1` as a sentinel for the default full-window width and fallback invalid `bar_edge` values to `top`.

### Description
- Registered new config values `plugin:hyprbars:bar_width` (INT, default `-1`), `plugin:hyprbars:bar_edge` (STRING, default `"top"`), and `plugin:hyprbars:bar_vertical_offset` (INT, default `0`) in `hyprbars/main.cpp` via `HyprlandAPI::addConfigValue`.
- Added `barEdgeFromConfig()` and mapped `bar_edge` to decoration edges so `"bottom"` selects `DECORATION_EDGE_BOTTOM` and all other values select `DECORATION_EDGE_TOP`, and used this edge in `CHyprBar::getPositioningInfo()` instead of always using top.
- Kept reserved extents height behavior but reserve on the selected edge (bottom vs top) by adjusting `info.desiredExtents`, and applied `bar_width` in `onPositioningReply()` to override assigned width when `> 0` (clamped to at least `1`) while preserving `-1` sentinel for default behavior.
- Updated `assignedBoxGlobal()` to call `getEdgeDefinedPoint()` with the selected edge and apply `bar_vertical_offset` by shifting the assigned box away from the chosen edge so input and rendering (which use `assignedBoxGlobal()`) follow the new placement.

### Testing
- Ran `git diff --check` which produced no whitespace or diff-check issues and succeeded.
- Verified working tree state via `git status --short` and confirmed the two modified files (`hyprbars/main.cpp`, `hyprbars/barDeco.cpp`).
- Confirmed commit contents with `git show --stat --oneline HEAD` and created a PR entry; all automated checks in the transcript succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d195ec92c8332b89df413f3b8b742)