### PR TITLE
hyprbars: add configurable vertical bar-content alignment

### DIFF
--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -77,6 +77,7 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      renderBarButtons(const Vector2D& bufferSize, const float scale);
     void                      renderBarButtonsText(CBox* barBox, const float scale, const float a);
     void                      damageOnButtonHover();
+    float                     getBarContentY(float barHeight, float contentHeight) const;
 
     bool                      inputIsValid();
     void                      onMouseButton(SCallbackInfo& info, IPointer::SButtonEvent e);

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -140,6 +140,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_blur", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_font", Hyprlang::STRING{"Sans"});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_align", Hyprlang::STRING{"center"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_content_v_align", Hyprlang::STRING{"default"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_content_vertical_offset", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_part_of_window", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_precedence_over_border", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_buttons_alignment", Hyprlang::STRING{"right"});


### PR DESCRIPTION
### Motivation
- Provide configurable vertical alignment and offset for bar content so titles, button icons and hit-testing can be positioned independently from the hardcoded centered layout.

### Description
- Add two new config keys in `PLUGIN_INIT`: `plugin:hyprbars:bar_content_v_align` (`STRING`, default `"default"`) and `plugin:hyprbars:bar_content_vertical_offset` (`INT`, default `0`) in `hyprbars/main.cpp`.
- Add a private helper `CHyprBar::getBarContentY(float barHeight, float contentHeight) const` (declared in `barDeco.hpp`, implemented in `barDeco.cpp`) that returns the content Y based on `top|center|bottom|default`, applies the signed offset and clamps the result so content cannot leave the bar bounds entirely.
- Use the helper to compute vertical positions consistently for title rendering (`renderBarTitle`), button circle centers (`renderBarButtons`), icon texture positions and hover/icon hit-tests (`renderBarButtonsText`), and button hit-test rectangles/hover checks (`doButtonPress` and `damageOnButtonHover`) so visual and interactive positions match.

### Testing
- Attempted to build the plugin with `make -C hyprbars`; the build could not complete in this environment because required system/Hyprland dependencies (e.g. `hyprland`, `pangocairo`, `pixman-1`, `libdrm`, `libinput`, `libudev`, `wayland-server`, `xkbcommon`) are missing and the compiler cannot find the Hyprland headers, so compilation failed.
- Verified the changes with local text searches (`rg`/`nl`) to ensure the helper was added and applied to all targeted rendering/hit-test locations and ran basic static checks in the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1a945f308332939f8b47caee7b13)