### PR TITLE
hyprbars: centralize bar geometry and button placement helpers

### DIFF
--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -78,6 +78,10 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      renderBarButtonsText(CBox* barBox, const float scale, const float a);
     void                      damageOnButtonHover();
     float                     getBarContentY(float barHeight, float contentHeight) const;
+    uint32_t                  getBarEdge() const;
+    int                       getConfiguredBarWidth() const;
+    CBox                      getResolvedBarBox(bool includeWorkspaceOffset) const;
+    Vector2D                  getButtonLogicalPos(float barWidth, float barHeight, float buttonSize, float offset, float buttonPadding, bool buttonsRight) const;
 
     bool                      inputIsValid();
     void                      onMouseButton(SCallbackInfo& info, IPointer::SButtonEvent e);


### PR DESCRIPTION
## Summary
- refactored hyprbars bar placement into reusable helpers on `CHyprBar`
- centralized edge/width/offset resolution with:
  - `getBarEdge`
  - `getConfiguredBarWidth`
  - `getResolvedBarBox`
- centralized button logical coordinate math with `getButtonLogicalPos`

## Details
- `getPositioningInfo` now uses helper-based edge/width resolution
- `onPositioningReply` now applies configured width via shared helper logic
- `assignedBoxGlobal` now delegates to `getResolvedBarBox(true)`
- updated button hit-test/hover/icon positioning paths to share the same button position helper:
  - `doButtonPress`
  - `renderBarButtonsText`
  - `damageOnButtonHover`

## Why
This reduces duplicated placement math and lowers the risk of future drift between render and input hit-testing when bar placement/content configs evolve.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d18c2abf483328663f4ef816246d8)