### PR TITLE
hyprbars: address helper review feedback and refresh 0.53.3 pin

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -23,6 +23,43 @@ uint32_t barEdgeFromConfig(const std::string& edge) {
 }
 }
 
+uint32_t CHyprBar::getBarEdge() const {
+    static auto* const PBAREDGE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_edge")->getDataStaticPtr();
+    return barEdgeFromConfig(*PBAREDGE);
+}
+
+int CHyprBar::getConfiguredBarWidth() const {
+    static auto* const PBARWIDTH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_width")->getDataStaticPtr();
+    return **PBARWIDTH == -1 ? -1 : std::max(1, **PBARWIDTH);
+}
+
+CBox CHyprBar::getResolvedBarBox() const {
+    static auto* const PVOFFSET = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_vertical_offset")->getDataStaticPtr();
+
+    if (!validMapped(m_pWindow))
+        return {};
+
+    const auto EDGE = getBarEdge();
+
+    CBox box = m_bAssignedBox;
+    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(EDGE, m_pWindow.lock()));
+
+    if (**PVOFFSET != 0)
+        box.y += EDGE == DECORATION_EDGE_BOTTOM ? **PVOFFSET : -**PVOFFSET;
+
+    const auto PWORKSPACE      = m_pWindow->m_workspace;
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    box.translate(WORKSPACEOFFSET);
+
+    return box;
+}
+
+Vector2D CHyprBar::getButtonLogicalPos(const float barWidth, const float barHeight, const float buttonSize, const float offset, const float buttonPadding,
+                                       const bool buttonsRight) const {
+    // bar/button values are in logical (unscaled) pixels; callers can scale the result where needed.
+    return Vector2D{buttonsRight ? barWidth - buttonPadding - buttonSize - offset : offset, getBarContentY(barHeight, buttonSize)}.floor();
+}
+
 CHyprBar::CHyprBar(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow) {
     m_pWindow = pWindow;
 
@@ -65,14 +102,9 @@ SDecorationPositioningInfo CHyprBar::getPositioningInfo() {
     static auto* const         PHEIGHT     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_height")->getDataStaticPtr();
     static auto* const         PENABLED    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:enabled")->getDataStaticPtr();
     static auto* const         PPRECEDENCE = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_precedence_over_border")->getDataStaticPtr();
-    static auto* const         PBARWIDTH   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_width")->getDataStaticPtr();
-    static auto* const         PBAREDGE    = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_edge")->getDataStaticPtr();
-    static auto* const         PVOFFSET    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_vertical_offset")->getDataStaticPtr();
 
-    const auto                 EDGE        = barEdgeFromConfig(*PBAREDGE);
+    const auto                 EDGE        = getBarEdge();
     const auto                 HEIGHT      = m_hidden || !**PENABLED ? 0 : **PHEIGHT;
-    const auto                 WIDTH       = **PBARWIDTH == -1 ? -1 : std::max(1, **PBARWIDTH);
-    (void)PVOFFSET;
 
     SDecorationPositioningInfo info;
     info.policy         = m_hidden ? DECORATION_POSITION_ABSOLUTE : DECORATION_POSITION_STICKY;
@@ -80,20 +112,18 @@ SDecorationPositioningInfo CHyprBar::getPositioningInfo() {
     info.priority       = **PPRECEDENCE ? 10005 : 5000;
     info.reserved       = true;
     info.desiredExtents = EDGE == DECORATION_EDGE_BOTTOM ? SBoxExtents{{0, 0}, {0, HEIGHT}} : SBoxExtents{{0, HEIGHT}, {0, 0}};
-    (void)WIDTH;
     return info;
 }
 
 void CHyprBar::onPositioningReply(const SDecorationPositioningReply& reply) {
-    static auto* const PBARWIDTH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_width")->getDataStaticPtr();
-
     if (reply.assignedGeometry.size() != m_bAssignedBox.size())
         m_bWindowSizeChanged = true;
 
     m_bAssignedBox = reply.assignedGeometry;
 
-    if (**PBARWIDTH != -1 && **PBARWIDTH > 0)
-        m_bAssignedBox.w = std::max(1, **PBARWIDTH);
+    const auto configuredWidth = getConfiguredBarWidth();
+    if (configuredWidth > 0)
+        m_bAssignedBox.w = configuredWidth;
 }
 
 std::string CHyprBar::getDisplayName() {
@@ -292,10 +322,11 @@ void CHyprBar::handleMovement() {
 bool CHyprBar::doButtonPress(Hyprlang::INT* const* PBARPADDING, Hyprlang::INT* const* PBARBUTTONPADDING, Hyprlang::INT* const* PHEIGHT, Vector2D COORDS, const bool BUTTONSRIGHT) {
     //check if on a button
     float offset = **PBARPADDING;
+    const auto barWidth = static_cast<float>(assignedBoxGlobal().w);
+    const auto barHeight = static_cast<float>(**PHEIGHT);
 
     for (auto& b : g_pGlobalState->buttons) {
-        const auto BARBUF     = Vector2D{(int)assignedBoxGlobal().w, **PHEIGHT};
-        Vector2D   currentPos = Vector2D{(BUTTONSRIGHT ? BARBUF.x - **PBARBUTTONPADDING - b.size - offset : offset), getBarContentY(BARBUF.y, b.size)}.floor();
+        Vector2D currentPos = getButtonLogicalPos(barWidth, barHeight, b.size, offset, static_cast<float>(**PBARBUTTONPADDING), BUTTONSRIGHT);
 
         if (VECINRECT(COORDS, currentPos.x, currentPos.y, currentPos.x + b.size + **PBARBUTTONPADDING, currentPos.y + b.size)) {
             // hit on close
@@ -566,6 +597,9 @@ void CHyprBar::renderBarButtonsText(CBox* barBox, const float scale, const float
 
     int                offset        = **PBARPADDING * scale;
     float              noScaleOffset = **PBARPADDING;
+    const auto         barWidth      = static_cast<float>(assignedBoxGlobal().w);
+    const auto         barHeight     = static_cast<float>(**PHEIGHT);
+    const auto         buttonPadding = static_cast<float>(**PBARBUTTONPADDING);
 
     for (size_t i = 0; i < visibleCount; ++i) {
         auto&      button           = g_pGlobalState->buttons[i];
@@ -573,10 +607,7 @@ void CHyprBar::renderBarButtonsText(CBox* barBox, const float scale, const float
         const auto scaledButtonsPad = **PBARBUTTONPADDING * scale;
 
         // check if hovering here
-        const auto BARBUF     = Vector2D{(int)assignedBoxGlobal().w, **PHEIGHT};
-        Vector2D   currentPos = Vector2D{(BUTTONSRIGHT ? BARBUF.x - **PBARBUTTONPADDING - button.size - noScaleOffset : noScaleOffset),
-                                           getBarContentY(BARBUF.y, button.size)}
-                                 .floor();
+        Vector2D   currentPos = getButtonLogicalPos(barWidth, barHeight, button.size, noScaleOffset, buttonPadding, BUTTONSRIGHT);
         bool       hovering   = VECINRECT(COORDS, currentPos.x, currentPos.y, currentPos.x + button.size + **PBARBUTTONPADDING, currentPos.y + button.size);
         noScaleOffset += **PBARBUTTONPADDING + button.size;
 
@@ -783,24 +814,7 @@ uint64_t CHyprBar::getDecorationFlags() {
 }
 
 CBox CHyprBar::assignedBoxGlobal() {
-    static auto* const PBAREDGE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_edge")->getDataStaticPtr();
-    static auto* const PVOFFSET = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_vertical_offset")->getDataStaticPtr();
-
-    if (!validMapped(m_pWindow))
-        return {};
-
-    const auto EDGE = barEdgeFromConfig(*PBAREDGE);
-
-    CBox box = m_bAssignedBox;
-    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(EDGE, m_pWindow.lock()));
-
-    if (**PVOFFSET != 0)
-        box.y += EDGE == DECORATION_EDGE_BOTTOM ? **PVOFFSET : -**PVOFFSET;
-
-    const auto PWORKSPACE      = m_pWindow->m_workspace;
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
-
-    return box.translate(WORKSPACEOFFSET);
+    return getResolvedBarBox();
 }
 
 PHLWINDOW CHyprBar::getOwner() {
@@ -837,12 +851,14 @@ void CHyprBar::damageOnButtonHover() {
     const bool         BUTTONSRIGHT      = std::string{*PALIGNBUTTONS} != "left";
 
     float              offset = **PBARPADDING;
+    const auto         barWidth = static_cast<float>(assignedBoxGlobal().w);
+    const auto         barHeight = static_cast<float>(**PHEIGHT);
+    const auto         buttonPadding = static_cast<float>(**PBARBUTTONPADDING);
 
     const auto         COORDS = cursorRelativeToBar();
 
     for (auto& b : g_pGlobalState->buttons) {
-        const auto BARBUF     = Vector2D{(int)assignedBoxGlobal().w, **PHEIGHT};
-        Vector2D   currentPos = Vector2D{(BUTTONSRIGHT ? BARBUF.x - **PBARBUTTONPADDING - b.size - offset : offset), getBarContentY(BARBUF.y, b.size)}.floor();
+        Vector2D   currentPos = getButtonLogicalPos(barWidth, barHeight, b.size, offset, buttonPadding, BUTTONSRIGHT);
 
         bool       hover = VECINRECT(COORDS, currentPos.x, currentPos.y, currentPos.x + b.size + **PBARBUTTONPADDING, currentPos.y + b.size);
 

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -78,6 +78,10 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      renderBarButtonsText(CBox* barBox, const float scale, const float a);
     void                      damageOnButtonHover();
     float                     getBarContentY(float barHeight, float contentHeight) const;
+    uint32_t                  getBarEdge() const;
+    int                       getConfiguredBarWidth() const;
+    CBox                      getResolvedBarBox() const;
+    Vector2D                  getButtonLogicalPos(float barWidth, float barHeight, float buttonSize, float offset, float buttonPadding, bool buttonsRight) const;
 
     bool                      inputIsValid();
     void                      onMouseButton(SCallbackInfo& info, IPointer::SButtonEvent e);

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -42,7 +42,7 @@ commit_pins = [
     ["ea444c35bb23b6e34505ab6753e069de7801cc25", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.0
     ["ab1d80f3d6aebd57a0971b53a1993b1c1dfe0b09", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.1
     ["39f3feddbee4a66be9608ed1eb7e73878d596b50", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.2
-    ["dd220efe7b1e292415bd0ea7161f63df9c95bfd3", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"]  # 0.53.3
+    ["dd220efe7b1e292415bd0ea7161f63df9c95bfd3", "7f2b8b0502c61ec64bf97f8619309b89398573b7"]  # 0.53.3
 ]
 
 [borders-plus-plus]


### PR DESCRIPTION
### Motivation
- Clean up follow-up issues from the earlier hyprbars helper refactor to remove unused parameters and dead/no-op logic. 
- Ensure the plugin pin for Hyprland 0.53.3 points at the latest plugin commit that includes these fixes. 

### Description
- Simplified `CHyprBar::getResolvedBarBox` by removing its unused `includeWorkspaceOffset` parameter and always applying the workspace offset in `hyprbars/barDeco.cpp` and the corresponding signature in `hyprbars/barDeco.hpp`. 
- Removed an unused width retrieval in `CHyprBar::getPositioningInfo` and switched it to use the new helper `getBarEdge`, while preserving width handling in `onPositioningReply` via `getConfiguredBarWidth`. 
- Updated all call sites to use the simplified helper, including `assignedBoxGlobal`, `doButtonPress`, `renderBarButtonsText`, and `damageOnButtonHover`, and centralized button coordinate math with `getButtonLogicalPos`. 
- Updated `hyprpm.toml` to refresh the 0.53.3 plugin commit pin to the new plugin commit `7f2b8b0502c61ec64bf97f8619309b89398573b7`. 

### Testing
- Verified repository state and diffs via `git log`, `git show`, and `git diff`, and committed the changes successfully. 
- Attempted to build the `hyprbars` plugin with `make -C hyprbars all`, which failed in this environment due to missing `hyprland` headers and required `pkg-config` libraries (e.g. `pixman-1`, `libdrm`, `pangocairo`, `libinput`, `libudev`, `wayland-server`, `xkbcommon`). 
- Confirmed `hyprpm.toml` was updated to reference the new plugin commit and recorded the new plugin commit in a commit to the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d18c2abf483328663f4ef816246d8)