### PR TITLE
Update hyprpm commit pin for Hyprland 0.53.3

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -42,7 +42,7 @@ commit_pins = [
     ["ea444c35bb23b6e34505ab6753e069de7801cc25", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.0
     ["ab1d80f3d6aebd57a0971b53a1993b1c1dfe0b09", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.1
     ["39f3feddbee4a66be9608ed1eb7e73878d596b50", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.2
-    ["dd220efe7b1e292415bd0ea7161f63df9c95bfd3", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"]  # 0.53.3
+    ["dd220efe7b1e292415bd0ea7161f63df9c95bfd3", "ec3e3e4dd840d11d0c3a8f26dd1b3bdb77f49b24"]  # 0.53.3
 ]
 
 [borders-plus-plus]


### PR DESCRIPTION
### Motivation
- Ensure the plugin commit pinned for Hyprland `0.53.3` in `hyprpm.toml` matches the intended repository state so builds use the correct code.

### Description
- Updated the `commit_pins` entry for `0.53.3` in `hyprpm.toml` to point from `64b7c2dff7e5e1fcb4cb7e5db078947744070e1a` to `ec3e3e4dd840d11d0c3a8f26dd1b3bdb77f49b24` for the plugin repository commit.
- The only modified file is `hyprpm.toml` and the change is a single-line replacement of the pinned commit for `0.53.3`.

### Testing
- Ran `git diff -- hyprpm.toml` to confirm the pin change and the diff shows only the intended line modification (success).
- Committed the change with `git commit` which completed successfully (success).
- Attempted to validate TOML loading with `python` and `tomllib` which failed due to `tomllib` not being available in the environment (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d2802514083328e056b55274b4839)