### PR TITLE
hyprbars: fix bar_width std::max type mismatch

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -30,7 +30,7 @@ uint32_t CHyprBar::getBarEdge() const {
 
 int CHyprBar::getConfiguredBarWidth() const {
     static auto* const PBARWIDTH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_width")->getDataStaticPtr();
-    return **PBARWIDTH == -1 ? -1 : std::max(1, **PBARWIDTH);
+    return **PBARWIDTH == -1 ? -1 : static_cast<int>(std::max<Hyprlang::INT>(1, **PBARWIDTH));
 }
 
 CBox CHyprBar::getResolvedBarBox(const bool includeWorkspaceOffset) const {


### PR DESCRIPTION
### Motivation
- Fix a build error caused by `std::max` template deduction when comparing an `int` literal with `Hyprlang::INT` (platform `long int`) in `getConfiguredBarWidth()` which produced a no-matching-function error on newer GCC versions.

### Description
- Change in `hyprbars/barDeco.cpp`: `CHyprBar::getConfiguredBarWidth()` now calls `std::max<Hyprlang::INT>(1, **PBARWIDTH)` and returns the result as `int` via `static_cast<int>`, ensuring both operands use the same type for template deduction.

### Testing
- Ran `make -C hyprbars all` in this environment; the original `std::max` template deduction error is addressed, but the build still fails here due to missing `pkg-config` dependencies and Hyprland headers (e.g. `pixman-1`, `hyprland`, `pangocairo`), so a full plugin build could not be completed in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d2c234d848332931f8c64b8bbd5da)