### PR TITLE
hyprpm: update 0.53.3 git pin

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -42,7 +42,7 @@ commit_pins = [
     ["ea444c35bb23b6e34505ab6753e069de7801cc25", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.0
     ["ab1d80f3d6aebd57a0971b53a1993b1c1dfe0b09", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.1
     ["39f3feddbee4a66be9608ed1eb7e73878d596b50", "64b7c2dff7e5e1fcb4cb7e5db078947744070e1a"], # 0.53.2
-    ["dd220efe7b1e292415bd0ea7161f63df9c95bfd3", "ec3e3e4dd840d11d0c3a8f26dd1b3bdb77f49b24"]  # 0.53.3
+    ["dd220efe7b1e292415bd0ea7161f63df9c95bfd3", "095278965bef181710d1a9a77cd7034fe23b83cf"]  # 0.53.3
 ]
 
 [borders-plus-plus]


### PR DESCRIPTION
### Motivation
- Ensure the `0.53.3` release entry in `hyprpm.toml` points to the correct repository commit so Hyprland plugins install the intended plugin code.

### Description
- Update the `commit_pins` entry for `0.53.3` in `hyprpm.toml` to `095278965bef181710d1a9a77cd7034fe23b83cf` and commit the change with message `hyprpm: update 0.53.3 git pin`.

### Testing
- Ran `git diff -- hyprpm.toml` and `git show -s` to verify the new pin and confirm the referenced commit exists, and the `git commit` succeeded; attempts to parse the TOML with `tomllib`/`toml` failed due to missing Python modules in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d2cc64b9c8332a954b5ea44367041)