### PR TITLE
hyprpill: fix narrowing conversion build failure

### DIFF
--- a/hyprpill/pillDeco.cpp
+++ b/hyprpill/pillDeco.cpp
@@ -121,19 +121,20 @@ void CHyprPill::renderPass(PHLMONITOR pMonitor, const float& a) {
     CHyprColor color = m_forcedColor.value_or(m_color);
     color.a *= std::clamp(m_opacity * a, 0.F, 1.F);
 
-    g_pHyprOpenGL->renderRect(box, color, {.round = m_radius * pMonitor->m_scale, .roundingPower = m_pWindow->roundingPower()});
+    g_pHyprOpenGL->renderRect(box, color,
+        {.round = std::max(0, std::lround(m_radius * pMonitor->m_scale)), .roundingPower = m_pWindow->roundingPower()});
 
     static auto* const PDEBUGHOVER = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:debug_hitbox_hover")->getDataStaticPtr();
     static auto* const PDEBUGCLICK = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:debug_hitbox_click")->getDataStaticPtr();
 
     if (**PDEBUGHOVER) {
         auto hoverBox = hoverHitboxGlobal().translate(-pMonitor->m_position);
-        g_pHyprOpenGL->renderRect(hoverBox, CHyprColor{0.35F, 0.8F, 1.F, 0.22F}, {.round = 0.F});
+        g_pHyprOpenGL->renderRect(hoverBox, CHyprColor{0.35F, 0.8F, 1.F, 0.22F}, {.round = 0});
     }
 
     if (**PDEBUGCLICK) {
         auto clickBox = clickHitboxGlobal().translate(-pMonitor->m_position);
-        g_pHyprOpenGL->renderRect(clickBox, CHyprColor{1.F, 0.5F, 0.3F, 0.22F}, {.round = 0.F});
+        g_pHyprOpenGL->renderRect(clickBox, CHyprColor{1.F, 0.5F, 0.3F, 0.22F}, {.round = 0});
     }
 
     if (m_targetState != m_currentState || **PDEBUGHOVER || **PDEBUGCLICK)


### PR DESCRIPTION
### Motivation
- The build was failing with narrowing-conversion errors in `CHyprPill::renderPass` when passing float values to the `renderRect` `.round` field, so the code needs to pass integer-compatible values to match the API.

### Description
- Changed the main pill rounding to `std::max(0, std::lround(m_radius * pMonitor->m_scale))` and replaced debug hitbox `.round = 0.F` with `.round = 0` in `hyprpill/pillDeco.cpp` to eliminate narrowing conversions.

### Testing
- Ran `make -C hyprpill`; compilation now proceeds past the previous narrowing-conversion errors but ultimately fails in this environment due to missing system/pkg-config development dependencies (`pixman-1`, `libdrm`, `hyprland`, `libinput`, `libudev`, `wayland-server`, `xkbcommon`, etc.).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5737f0ac8332b89a83f3630f4b83)