### PR TITLE
hyprpill: fix pill drag capture and hover interference

### DIFF
--- a/hyprpill/globals.hpp
+++ b/hyprpill/globals.hpp
@@ -10,6 +10,7 @@ struct SGlobalState {
     std::vector<WP<CHyprPill>> pills;
     uint32_t                   noPillRuleIdx    = 0;
     uint32_t                   pillColorRuleIdx = 0;
+    WP<CHyprPill>              dragPill;
 };
 
 inline UP<SGlobalState> g_pGlobalState;


### PR DESCRIPTION
### Motivation

- The pill grabber could be distracted by other pills during a drag and could also prevent window movement while the cursor remained inside the hover hitbox, causing unreliable drag behavior.  
- Drag ownership must be tied to the pill that started the drag so pills only move their own attached windows.  

### Description

- Add a global `dragPill` owner to `SGlobalState` so a single pill instance can own a drag at a time by introducing `WP<CHyprPill> dragPill` in `hyprpill/globals.hpp`.  
- In `beginDrag`, refuse to start a drag if another pill already owns the drag and set `g_pGlobalState->dragPill = m_self` when this pill successfully starts dragging.  
- Clear `dragPill` on `endDrag` and in the pill destructor to avoid stale ownership.  
- In `onMouseMove`, ignore hover/focus logic for pills that do not own the current drag and only cancel mouse events / steal focus when not pending/actively dragging; ensure focus is restored to the owning window before issuing `movewindow`.  

### Testing

- Attempted to build with `make -C hyprpill -j4`, which failed in this environment due to missing Hyprland/Wayland development dependencies and `pkg-config` entries, so compilation could not be validated here.  
- No other automated tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5f3b7eb483328c676aeb88e052e6)