### PR TITLE
hyprpill: drag threshold + cursor debug; fix tiled drag and hover cursor

### DIFF
--- a/hyprpill/README.md
+++ b/hyprpill/README.md
@@ -30,9 +30,11 @@ plugin {
 
     debug_hitbox_hover = false
     debug_hitbox_click = false
+    debug_cursor_state = false
 
     hover_cursor = grab
     grab_cursor = grabbing
+    drag_pixel_threshold = 8
 
     pill_color_active = rgba(99ccffff)
     pill_color_inactive = rgba(777777cc)
@@ -79,8 +81,10 @@ All config options are in `plugin:hyprpill`.
 | `click_hitbox_offset_y` | int | click hitbox y offset from visible pill | `0` |
 | `debug_hitbox_hover` | bool | draw hover hitbox overlay for tuning | `false` |
 | `debug_hitbox_click` | bool | draw click hitbox overlay for tuning | `false` |
-| `hover_cursor` | str | cursor shape name while hovering click hitbox (`""` to disable override) | `grab` |
+| `debug_cursor_state` | bool | draw a state indicator showing whether hyprpill expects default/hover/grab cursor | `false` |
+| `hover_cursor` | str | cursor shape name while hovering the hover hitbox (`""` to disable override) | `grab` |
 | `grab_cursor` | str | cursor shape name while click/drag is active (`""` to disable override) | `grabbing` |
+| `drag_pixel_threshold` | int | movement threshold in px before a press turns into a window drag | `8` |
 | `pill_color_active` | color | active/focused color | `rgba(99ccffff)` |
 | `pill_color_inactive` | color | inactive color | `rgba(777777cc)` |
 | `pill_color_hover` | color | hover color | `rgba(bbe6ffff)` |

--- a/hyprpill/main.cpp
+++ b/hyprpill/main.cpp
@@ -78,8 +78,10 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:click_hitbox_offset_y", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:debug_hitbox_hover", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:debug_hitbox_click", Hyprlang::INT{0});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:debug_cursor_state", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:hover_cursor", Hyprlang::STRING{"grab"});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:grab_cursor", Hyprlang::STRING{"grabbing"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:drag_pixel_threshold", Hyprlang::INT{8});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:pill_color_active", Hyprlang::INT{*configStringToInt("rgba(99ccffff)")});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:pill_color_inactive", Hyprlang::INT{*configStringToInt("rgba(777777cc)")});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:pill_color_hover", Hyprlang::INT{*configStringToInt("rgba(bbe6ffff)")});
@@ -104,7 +106,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::reloadConfig();
 
-    return {"hyprpill", "A plugin to add animated pill grabbers to windows.", "Vaxry", "1.0"};
+    return {"hyprpill", "A plugin to add animated pill grabbers to windows.", "mylescox", "1.0"};
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {

--- a/hyprpill/pillDeco.cpp
+++ b/hyprpill/pillDeco.cpp
@@ -145,7 +145,27 @@ void CHyprPill::renderPass(PHLMONITOR pMonitor, const float& a) {
         g_pHyprOpenGL->renderRect(clickBox, CHyprColor{1.F, 0.5F, 0.3F, 0.22F}, {.round = 0});
     }
 
-    if (m_targetState != m_currentState || **PDEBUGHOVER || **PDEBUGCLICK)
+    static auto* const PDEBUGCURSOR = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:debug_cursor_state")->getDataStaticPtr();
+    if (**PDEBUGCURSOR) {
+        const auto cursorPos = g_pInputManager->getMouseCoordsInternal();
+        const bool overPill  = inputIsValid(true) && VECINRECT(cursorPos, hoverHitboxGlobal().x, hoverHitboxGlobal().y, hoverHitboxGlobal().x + hoverHitboxGlobal().w, hoverHitboxGlobal().y + hoverHitboxGlobal().h);
+
+        CBox indicator = box;
+        indicator.w    = std::max(6, std::lround(10.F * pMonitor->m_scale));
+        indicator.h    = indicator.w;
+        indicator.x    = box.x + box.w - indicator.w;
+        indicator.y    = box.y - indicator.h - std::max(1, std::lround(2.F * pMonitor->m_scale));
+
+        CHyprColor indicatorColor = CHyprColor{0.6F, 0.6F, 0.6F, 0.8F};
+        if (m_dragPending || m_draggingThis)
+            indicatorColor = CHyprColor{1.F, 0.65F, 0.2F, 0.95F};
+        else if (overPill)
+            indicatorColor = CHyprColor{0.2F, 0.9F, 0.35F, 0.95F};
+
+        g_pHyprOpenGL->renderRect(indicator, indicatorColor, {.round = 0});
+    }
+
+    if (m_targetState != m_currentState || **PDEBUGHOVER || **PDEBUGCLICK || **PDEBUGCURSOR)
         damageEntire();
 }
 
@@ -213,14 +233,16 @@ bool CHyprPill::isHovering() const {
     return VECINRECT(coords, hb.x, hb.y, hb.x + hb.w, hb.y + hb.h);
 }
 
-bool CHyprPill::inputIsValid() {
+bool CHyprPill::inputIsValid(bool ignoreSeatGrab) {
     static auto* const PENABLED = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:enabled")->getDataStaticPtr();
 
     if (!**PENABLED || m_hidden)
         return false;
 
-    if (!m_pWindow->m_workspace || !m_pWindow->m_workspace->isVisible() || !g_pInputManager->m_exclusiveLSes.empty() ||
-        (g_pSeatManager->m_seatGrab && !g_pSeatManager->m_seatGrab->accepts(m_pWindow->wlSurface()->resource())))
+    if (!m_pWindow->m_workspace || !m_pWindow->m_workspace->isVisible() || !g_pInputManager->m_exclusiveLSes.empty())
+        return false;
+
+    if (!ignoreSeatGrab && g_pSeatManager->m_seatGrab && !g_pSeatManager->m_seatGrab->accepts(m_pWindow->wlSurface()->resource()))
         return false;
 
     return true;
@@ -245,6 +267,8 @@ void CHyprPill::beginDrag(SCallbackInfo& info, const Vector2D& coordsGlobal) {
         g_pCompositor->changeWindowZOrder(PWINDOW, true);
 
     m_dragCursorOffset = coordsGlobal - (PWINDOW->m_realPosition->value() + PWINDOW->m_floatingOffset);
+    m_dragStartCoords  = coordsGlobal;
+    m_startedMouseDrag = false;
 
     info.cancelled   = true;
     m_cancelledDown  = true;
@@ -265,8 +289,12 @@ void CHyprPill::endDrag(SCallbackInfo& info) {
     if (m_draggingThis && m_touchEv)
         g_pKeybindManager->m_dispatchers["settiled"]("activewindow");
 
-    m_dragPending  = false;
-    m_draggingThis = false;
+    if (m_startedMouseDrag)
+        g_pKeybindManager->m_dispatchers["mouse"]("0movewindow");
+
+    m_dragPending     = false;
+    m_draggingThis    = false;
+    m_startedMouseDrag = false;
     m_touchEv      = false;
     m_touchId      = 0;
 
@@ -326,13 +354,18 @@ void CHyprPill::onMouseMove(SCallbackInfo& info, Vector2D coords) {
 
     if (m_draggingThis) {
         info.cancelled = true;
-        updateDragPosition(coords);
+        if (!m_startedMouseDrag)
+            updateDragPosition(coords);
         updateCursorShape(coords);
         return;
     }
 
-    const auto hb = hoverHitboxGlobal();
-    m_hovered     = VECINRECT(coords, hb.x, hb.y, hb.x + hb.w, hb.y + hb.h);
+    const auto hb    = hoverHitboxGlobal();
+    const bool wasHovered = m_hovered;
+    m_hovered        = VECINRECT(coords, hb.x, hb.y, hb.x + hb.w, hb.y + hb.h);
+
+    if (m_hovered != wasHovered)
+        damageEntire();
 
     if (m_hovered) {
         if (!m_dragPending && Desktop::focusState()->window() != m_pWindow.lock())
@@ -347,33 +380,49 @@ void CHyprPill::onMouseMove(SCallbackInfo& info, Vector2D coords) {
         return;
     }
 
+    static auto* const PDRAGTHRESH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:drag_pixel_threshold")->getDataStaticPtr();
+    const auto dragDelta           = coords - m_dragStartCoords;
+    const float dragDistance       = std::sqrt(dragDelta.x * dragDelta.x + dragDelta.y * dragDelta.y);
+    if (dragDistance < std::max<Hyprlang::INT>(0, **PDRAGTHRESH)) {
+        updateCursorShape(coords);
+        return;
+    }
+
     if (Desktop::focusState()->window() != m_pWindow.lock())
         Desktop::focusState()->fullWindowFocus(m_pWindow.lock());
 
-    m_dragPending  = false;
-    info.cancelled = true;
-    updateDragPosition(coords);
+    m_dragPending      = false;
+    m_draggingThis     = true;
+    m_startedMouseDrag = true;
+    info.cancelled     = true;
+    g_pKeybindManager->m_dispatchers["mouse"]("1movewindow");
     updateCursorShape(coords);
 }
 
 void CHyprPill::onTouchMove(SCallbackInfo& info, ITouch::SMotionEvent e) {
-    if (!m_dragPending || !m_touchEv || e.touchID != m_touchId || !validMapped(m_pWindow))
+    if ((!m_dragPending && !m_draggingThis) || !m_touchEv || e.touchID != m_touchId || !validMapped(m_pWindow))
         return;
 
     auto PMONITOR     = m_pWindow->m_monitor.lock();
     PMONITOR          = PMONITOR ? PMONITOR : Desktop::focusState()->monitor();
     const auto COORDS = Vector2D(PMONITOR->m_position.x + e.pos.x * PMONITOR->m_size.x, PMONITOR->m_position.y + e.pos.y * PMONITOR->m_size.y);
 
+    static auto* const PDRAGTHRESH = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:drag_pixel_threshold")->getDataStaticPtr();
+    if (!m_draggingThis) {
+        const auto dragDelta     = COORDS - m_dragStartCoords;
+        const float dragDistance = std::sqrt(dragDelta.x * dragDelta.x + dragDelta.y * dragDelta.y);
+        if (dragDistance < std::max<Hyprlang::INT>(0, **PDRAGTHRESH))
+            return;
+
+        m_dragPending = false;
+    }
+
+    info.cancelled = true;
     updateDragPosition(COORDS);
+    updateCursorShape(COORDS);
 }
 
 void CHyprPill::updateDragPosition(const Vector2D& coordsGlobal) {
-    if (!m_draggingThis && !m_pWindow->m_isFloating) {
-        g_pKeybindManager->m_dispatchers["setfloating"]("activewindow");
-        g_pKeybindManager->m_dispatchers["resizewindowpixel"]("exact 50% 50%,activewindow");
-        g_pKeybindManager->m_dispatchers["pin"]("activewindow");
-    }
-
     const auto targetPos = coordsGlobal - m_dragCursorOffset;
     g_pKeybindManager->m_dispatchers["movewindowpixel"](std::format("exact {} {},activewindow", (int)targetPos.x, (int)targetPos.y));
     m_draggingThis = true;
@@ -406,10 +455,10 @@ void CHyprPill::updateCursorShape(const std::optional<Vector2D>& coords) {
     const auto COORDS = coords.value_or(g_pInputManager->getMouseCoordsInternal());
     for (auto& p : g_pGlobalState->pills) {
         const auto PPILL = p.lock();
-        if (!PPILL || !PPILL->inputIsValid())
+        if (!PPILL || !PPILL->inputIsValid(true))
             continue;
 
-        const auto HB = PPILL->clickHitboxGlobal();
+        const auto HB = PPILL->hoverHitboxGlobal();
         if (VECINRECT(COORDS, HB.x, HB.y, HB.x + HB.w, HB.y + HB.h)) {
             if (!HOVERCURSOR.empty())
                 Cursor::overrideController->setOverride(HOVERCURSOR, Cursor::CURSOR_OVERRIDE_UNKNOWN);

--- a/hyprpill/pillDeco.hpp
+++ b/hyprpill/pillDeco.hpp
@@ -56,7 +56,7 @@ class CHyprPill : public IHyprWindowDecoration {
     void                      updateStateAndAnimate();
     void                      updateDragPosition(const Vector2D& coordsGlobal);
     void                      updateCursorShape(const std::optional<Vector2D>& coords = std::nullopt);
-    bool                      inputIsValid();
+    bool                      inputIsValid(bool ignoreSeatGrab = false);
     Vector2D                  cursorRelativeToPill() const;
     bool                      isHovering() const;
 
@@ -70,8 +70,10 @@ class CHyprPill : public IHyprWindowDecoration {
     bool                      m_touchEv         = false;
     bool                      m_cancelledDown   = false;
     bool                      m_hovered         = false;
+    bool                      m_startedMouseDrag = false;
     int                       m_touchId         = 0;
     Vector2D                  m_dragCursorOffset;
+    Vector2D                  m_dragStartCoords;
 
     ePillVisualState          m_currentState    = ePillVisualState::INACTIVE;
     ePillVisualState          m_targetState     = ePillVisualState::INACTIVE;


### PR DESCRIPTION
### Motivation
- Tiled windows could not be moved via the pill because dragging forced/expected floating behavior and the pointer-based drag path was not used.
- The pointer cursor override did not reliably update when moving slowly into the pill hitbox and there was no easy visual to verify cursor-intent state. 
- Add a configurable guard so accidental small movements do not immediately start window drags and make author metadata reflect ownership.

### Description
- Introduce a new config `plugin:hyprpill:drag_pixel_threshold` (default `8`) and `plugin:hyprpill:debug_cursor_state` in `main.cpp` and document both in `README.md`.
- Add per-pill state fields `m_dragStartCoords` and `m_startedMouseDrag`, track the initial press coordinates in `beginDrag`, and only start a window move after the distance exceeds the configured threshold in `onMouseMove` and `onTouchMove`.
- Switch pointer drags to Hyprland's `mouse 1movewindow` flow when the threshold is crossed and end with `mouse 0movewindow` in `endDrag` if the mouse-driven move was started, so tiled windows move without being converted to floating (no forced `setfloating`/`resizewindowpixel`/`pin`).
- Relax cursor validity checks for hover cursor evaluation by adding `inputIsValid(bool ignoreSeatGrab)` and using `ignoreSeatGrab` when drawing / checking hover state, and use the larger `hoverHitboxGlobal()` for hover cursor detection in `updateCursorShape` so the hover cursor applies predictably.
- Add a small debug indicator rendered in `renderPass` (controlled by `debug_cursor_state`) that shows the pill's expected cursor intent (gray=default, green=hover, orange/grab=drag) to help diagnose cursor-change issues.
- Update plugin metadata author to `mylescox`.

### Testing
- Attempted build: ran `cmake -S . -B build && cmake --build build -j4`, which failed in this environment due to missing system dependencies (`hyprland`, `libdrm`, `libinput`, `libudev`, `pangocairo`, `pixman-1`, `wayland-server`, `xkbcommon`).
- Performed local static validation by grepping and inspecting diffs for the changed symbols and behavior; no unit tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9c07b5a4833281f4ee0fa4f75272)