### PR TITLE
Add occluder-aware horizontal dodge constraints for hyprpill

### DIFF
--- a/hyprpill/README.md
+++ b/hyprpill/README.md
@@ -31,6 +31,7 @@ plugin {
     hover_hitbox_width = 10
     hover_hitbox_height = 8
     hover_hitbox_offset_y = 0
+    dodge_occluder_margin = 4
 
     click_hitbox_width = 10
     click_hitbox_height = 8
@@ -85,6 +86,7 @@ All config options are in `plugin:hyprpill`.
 | `hover_hitbox_width` | int | extra horizontal hover hitbox padding | `10` |
 | `hover_hitbox_height` | int | extra vertical hover hitbox padding | `8` |
 | `hover_hitbox_offset_y` | int | hover hitbox y offset from visible pill | `0` |
+| `dodge_occluder_margin` | int | extra horizontal padding used when avoiding top-edge occluding windows | `4` |
 | `click_hitbox_width` | int | extra horizontal click/drag hitbox padding | `10` |
 | `click_hitbox_height` | int | extra vertical click/drag hitbox padding | `8` |
 | `click_hitbox_offset_y` | int | click hitbox y offset from visible pill | `0` |

--- a/hyprpill/main.cpp
+++ b/hyprpill/main.cpp
@@ -73,6 +73,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:hover_hitbox_width", Hyprlang::INT{10});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:hover_hitbox_height", Hyprlang::INT{8});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:hover_hitbox_offset_y", Hyprlang::INT{0});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:dodge_occluder_margin", Hyprlang::INT{4});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:click_hitbox_width", Hyprlang::INT{10});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:click_hitbox_height", Hyprlang::INT{8});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprpill:click_hitbox_offset_y", Hyprlang::INT{0});

--- a/hyprpill/pillDeco.cpp
+++ b/hyprpill/pillDeco.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <format>
 #include <string>
+#include <tuple>
+#include <vector>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/desktop/rule/windowRule/WindowRule.hpp>
@@ -33,6 +35,51 @@ CHyprColor lerpColor(const CHyprColor& a, const CHyprColor& b, float t) {
 
 float easeInOut(float t) {
     return t < 0.5F ? 2.F * t * t : 1.F - std::pow(-2.F * t + 2.F, 2.F) * 0.5F;
+}
+
+struct SHorizontalInterval {
+    float start = 0.F;
+    float end   = 0.F;
+};
+
+bool intervalsOverlap(const SHorizontalInterval& a, const SHorizontalInterval& b) {
+    return a.start < b.end && b.start < a.end;
+}
+
+std::vector<SHorizontalInterval> subtractForbiddenIntervals(const SHorizontalInterval& domain, std::vector<SHorizontalInterval> forbidden) {
+    if (domain.end <= domain.start)
+        return {};
+
+    if (forbidden.empty())
+        return {domain};
+
+    std::sort(forbidden.begin(), forbidden.end(), [](const auto& a, const auto& b) { return a.start < b.start; });
+
+    std::vector<SHorizontalInterval> merged;
+    merged.reserve(forbidden.size());
+    for (const auto& interval : forbidden) {
+        SHorizontalInterval clipped = {std::max(domain.start, interval.start), std::min(domain.end, interval.end)};
+        if (clipped.end <= clipped.start)
+            continue;
+
+        if (!merged.empty() && intervalsOverlap(merged.back(), clipped))
+            merged.back().end = std::max(merged.back().end, clipped.end);
+        else
+            merged.push_back(clipped);
+    }
+
+    std::vector<SHorizontalInterval> allowed;
+    float                           cursor = domain.start;
+    for (const auto& blocked : merged) {
+        if (blocked.start > cursor)
+            allowed.push_back({cursor, blocked.start});
+        cursor = std::max(cursor, blocked.end);
+    }
+
+    if (cursor < domain.end)
+        allowed.push_back({cursor, domain.end});
+
+    return allowed;
 }
 }
 
@@ -185,6 +232,10 @@ void CHyprPill::damageEntire() {
 
 CBox CHyprPill::visibleBoxGlobal() const {
     static auto* const PWIDTH  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:pill_width")->getDataStaticPtr();
+    static auto* const PHITW   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:hover_hitbox_width")->getDataStaticPtr();
+    static auto* const PHITH   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:hover_hitbox_height")->getDataStaticPtr();
+    static auto* const POFFY   = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:hover_hitbox_offset_y")->getDataStaticPtr();
+    static auto* const POCCMARGIN = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprpill:dodge_occluder_margin")->getDataStaticPtr();
 
     CBox box = m_bAssignedBox;
     box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_pWindow.lock()));
@@ -193,10 +244,172 @@ CBox CHyprPill::visibleBoxGlobal() const {
     const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
     box.translate(WORKSPACEOFFSET);
 
+    const auto windowLeft = static_cast<float>(box.x);
+    const auto windowRight = static_cast<float>(box.x + box.w);
     const auto centerX = box.x + box.w / 2.F;
-    box.w              = std::max<int>(1, std::lround(m_width > 1.F ? m_width : **PWIDTH));
+    const auto desiredWidth = std::max<int>(1, std::lround(m_width > 1.F ? m_width : **PWIDTH));
+    box.w = std::min<int>(desiredWidth, std::max<int>(1, std::lround(windowRight - windowLeft)));
     box.h              = std::max<int>(1, std::lround(m_height));
-    box.x              = std::lround(centerX - box.w / 2.F);
+
+    if (m_dragGeometryLocked && (m_dragPending || m_draggingThis)) {
+        box.w = std::clamp(m_dragLockedResolvedW, 1, std::max<int>(1, std::lround(windowRight - windowLeft)));
+        box.x = std::clamp(m_dragLockedResolvedX, std::lround(windowLeft), std::lround(windowRight - box.w));
+        box.y = std::lround(box.y - box.h - m_offsetY);
+        return box;
+    }
+
+    std::vector<SHorizontalInterval> occluders;
+    occluders.reserve(g_pCompositor->m_windows.size());
+
+    const auto owner = m_pWindow.lock();
+    const bool canDetectOccluders = owner && owner->m_workspace && owner->m_workspace->isVisible();
+    if (canDetectOccluders) {
+        const float hoverWidthPad  = std::max<Hyprlang::INT>(0, **PHITW);
+        const float hoverHeightPad = std::max<Hyprlang::INT>(0, **PHITH);
+        const float hoverOffsetY   = **POFFY;
+        const float occluderMargin = std::max<Hyprlang::INT>(0, **POCCMARGIN);
+
+        const float basePillY      = std::lround(box.y - box.h - m_offsetY);
+        const float hoverTop       = std::lround(basePillY - hoverHeightPad + hoverOffsetY);
+        const float hoverBottom    = hoverTop + box.h + hoverHeightPad * 2.F;
+
+        for (const auto& candidate : g_pCompositor->m_windows) {
+            if (!candidate || candidate == owner || candidate->isHidden() || !candidate->m_isMapped)
+                continue;
+
+            if (!candidate->m_workspace || !candidate->m_workspace->isVisible())
+                continue;
+
+            if (candidate->m_monitor != owner->m_monitor)
+                continue;
+
+            const auto candidatePos = candidate->m_realPosition->value() + candidate->m_floatingOffset;
+            const auto candidateSize = candidate->m_realSize->value();
+
+            const float candidateLeft   = candidatePos.x;
+            const float candidateTop    = candidatePos.y;
+            const float candidateRight  = candidateLeft + candidateSize.x;
+            const float candidateBottom = candidateTop + candidateSize.y;
+
+            const bool overlapsHoverY = candidateBottom > hoverTop && candidateTop < hoverBottom;
+            if (!overlapsHoverY)
+                continue;
+
+            // Only dodge when an occluder edge actually intersects the hover hitbox vertically.
+            const bool hasTouchingEdge = (candidateBottom >= hoverTop && candidateBottom <= hoverBottom) || (candidateTop >= hoverTop && candidateTop <= hoverBottom);
+            if (!hasTouchingEdge)
+                continue;
+
+            // Require top-edge occlusion behavior so side-only overlaps do not trigger dodging.
+            const bool occludesFromTop = candidateBottom >= hoverTop && candidateBottom <= hoverBottom;
+            if (!occludesFromTop)
+                continue;
+
+            const float clippedLeft  = std::max(windowLeft, candidateLeft - occluderMargin);
+            const float clippedRight = std::min(windowRight, candidateRight + occluderMargin);
+            if (clippedRight <= clippedLeft)
+                continue;
+
+            occluders.push_back({clippedLeft, clippedRight});
+        }
+    }
+
+    auto solveConstrained = [&](float width, bool& dodging) {
+        const float halfW = std::max(0.5F, width / 2.F);
+        SHorizontalInterval domain{windowLeft + halfW, windowRight - halfW};
+        domain.end = std::max(domain.end, domain.start);
+
+        std::vector<SHorizontalInterval> forbidden;
+        forbidden.reserve(occluders.size());
+        const float hitPad = std::max<Hyprlang::INT>(0, **PHITW);
+        const float avoidDistance = hitPad + halfW;
+        for (const auto& occ : occluders)
+            forbidden.push_back({occ.start - avoidDistance, occ.end + avoidDistance});
+
+        const auto allowed = subtractForbiddenIntervals(domain, forbidden);
+        const bool centerAllowed = std::ranges::any_of(allowed, [&](const auto& interval) { return centerX >= interval.start && centerX <= interval.end; });
+
+        float resolvedCenter = std::clamp(centerX, domain.start, domain.end);
+        if (!allowed.empty()) {
+            if (centerAllowed) {
+                resolvedCenter = std::clamp(centerX, domain.start, domain.end);
+                dodging = false;
+            } else {
+                dodging = true;
+                bool foundLeftOfCenter  = false;
+                bool foundRightOfCenter = false;
+
+                SHorizontalInterval bestLeft;
+                SHorizontalInterval bestRight;
+
+                for (const auto& interval : allowed) {
+                    if (interval.end <= centerX) {
+                        if (!foundLeftOfCenter || interval.end > bestLeft.end) {
+                            bestLeft = interval;
+                            foundLeftOfCenter = true;
+                        }
+                    } else if (interval.start >= centerX) {
+                        if (!foundRightOfCenter || interval.start < bestRight.start) {
+                            bestRight = interval;
+                            foundRightOfCenter = true;
+                        }
+                    }
+                }
+
+                if (foundLeftOfCenter && foundRightOfCenter) {
+                    const float leftGap  = bestLeft.end - bestLeft.start;
+                    const float rightGap = bestRight.end - bestRight.start;
+
+                    if (std::abs(leftGap - rightGap) < 0.001F) {
+                        // Perfectly centered ambiguity prefers left side.
+                        resolvedCenter = bestLeft.end;
+                    } else {
+                        resolvedCenter = leftGap > rightGap ? bestLeft.end : bestRight.start;
+                    }
+                } else if (foundLeftOfCenter) {
+                    resolvedCenter = bestLeft.end;
+                } else if (foundRightOfCenter) {
+                    resolvedCenter = bestRight.start;
+                } else {
+                    const auto& nearest = *std::min_element(allowed.begin(), allowed.end(), [&](const auto& a, const auto& b) {
+                        const float da = std::min(std::abs(centerX - a.start), std::abs(centerX - a.end));
+                        const float db = std::min(std::abs(centerX - b.start), std::abs(centerX - b.end));
+                        return da < db;
+                    });
+                    resolvedCenter = std::clamp(centerX, nearest.start, nearest.end);
+                }
+            }
+        } else {
+            // If no non-occluding placement exists, gracefully return to center.
+            dodging = false;
+            resolvedCenter = std::clamp(centerX, domain.start, domain.end);
+        }
+
+        float leftLimit  = windowLeft;
+        float rightLimit = windowRight;
+        for (const auto& occ : occluders) {
+            if (resolvedCenter <= occ.start)
+                rightLimit = std::min(rightLimit, occ.start - std::max<Hyprlang::INT>(0, **PHITW));
+            else if (resolvedCenter >= occ.end)
+                leftLimit = std::max(leftLimit, occ.end + std::max<Hyprlang::INT>(0, **PHITW));
+        }
+
+        const float maxHalfWidth = std::max(0.5F, std::min(resolvedCenter - leftLimit, rightLimit - resolvedCenter));
+        const float maxWidth = std::max(1.F, maxHalfWidth * 2.F);
+        return std::pair{resolvedCenter, std::min(width, maxWidth)};
+    };
+
+    bool dodging = false;
+    auto [resolvedCenter, resolvedWidth] = solveConstrained(static_cast<float>(box.w), dodging);
+    std::tie(resolvedCenter, resolvedWidth) = solveConstrained(resolvedWidth, dodging);
+
+    box.w = std::max<int>(1, std::lround(resolvedWidth));
+    box.x = std::clamp(std::lround(resolvedCenter - box.w / 2.F), std::lround(windowLeft), std::lround(windowRight - box.w));
+
+    m_lastFrameDodging   = dodging;
+    m_lastFrameResolvedX = box.x;
+    m_lastFrameResolvedW = box.w;
+
     box.y              = std::lround(box.y - box.h - m_offsetY);
     return box;
 }
@@ -274,6 +487,10 @@ void CHyprPill::beginDrag(SCallbackInfo& info, const Vector2D& coordsGlobal) {
     m_dragCursorOffset = coordsGlobal - (PWINDOW->m_realPosition->value() + PWINDOW->m_floatingOffset);
     m_dragStartCoords  = coordsGlobal;
 
+    m_dragGeometryLocked  = m_lastFrameDodging;
+    m_dragLockedResolvedX = m_lastFrameResolvedX;
+    m_dragLockedResolvedW = m_lastFrameResolvedW;
+
     info.cancelled   = true;
     m_cancelledDown  = true;
     m_dragPending    = true;
@@ -302,6 +519,7 @@ void CHyprPill::endDrag(SCallbackInfo& info) {
     m_dragPending       = false;
     m_draggingThis      = false;
     m_forceFloatForDrag = false;
+    m_dragGeometryLocked = false;
     m_touchEv           = false;
     m_touchId      = 0;
 

--- a/hyprpill/pillDeco.hpp
+++ b/hyprpill/pillDeco.hpp
@@ -100,6 +100,13 @@ class CHyprPill : public IHyprWindowDecoration {
     float                     m_fromOffsetY     = 0.F;
     CHyprColor                m_fromColor;
 
+    mutable bool              m_lastFrameDodging     = false;
+    mutable int               m_lastFrameResolvedX   = 0;
+    mutable int               m_lastFrameResolvedW   = 0;
+    bool                      m_dragGeometryLocked   = false;
+    int                       m_dragLockedResolvedX  = 0;
+    int                       m_dragLockedResolvedW  = 0;
+
     SP<HOOK_CALLBACK_FN>      m_pMouseButtonCallback;
     SP<HOOK_CALLBACK_FN>      m_pTouchDownCallback;
     SP<HOOK_CALLBACK_FN>      m_pTouchUpCallback;


### PR DESCRIPTION
### Motivation
- Let the pill slide horizontally to avoid windows that would otherwise occlude its hover hitbox while keeping placement robust and visually smooth. 
- Ensure the pill only dodges when an occluding window actually intersects the hover hitbox edge, never slides past the owning window edges, and handles two-sided occlusion or perfectly centered occluders deterministically. 
- Prevent geometry snapping mid-drag by holding the resolved dodged geometry for the duration of a drag.

### Description
- Implemented interval helpers and a dodge solver used from `CHyprPill::visibleBoxGlobal()` (`SHorizontalInterval`, `subtractForbiddenIntervals`) to compute allowed in-window center ranges while subtracting forbidden ranges created from occluders. 
- Detect occluding windows by scanning `g_pCompositor->m_windows` and only consider candidates that intersect the pill's hover hitbox vertically and present a top-edge intersection; apply a configurable occluder padding from the new config `plugin:hyprpill:dodge_occluder_margin`. 
- Constrain pill center and width so the pill remains inside its window bounds and tries to reach the animated target width; choose dodge side by preferring the larger gap and resolving perfect-center ambiguity to the left, and fall back to centered placement when no non-occluding placement exists. 
- Lock resolved pill x/width during drag by adding members to `pillDeco.hpp` and setting/unsetting them in `beginDrag()` / `endDrag()` so an ongoing drag does not snap the pill back to a non-dodged position. 
- Registered `plugin:hyprpill:dodge_occluder_margin` (default `4`) in `main.cpp` and documented it in `README.md`.

### Testing
- Attempted an automated build with `make -C hyprpill`, which failed in this environment due to missing external pkg-config/Hyprland development dependencies (`hyprland`, `pixman-1`, `wayland-server`, etc.), so compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698db69621cc8332bb848d86adac0da5)