### PR TITLE
hyprpill: revert interaction regressions, keep hover dodge stabilization only

### DIFF
--- a/hyprpill/pillDeco.cpp
+++ b/hyprpill/pillDeco.cpp
@@ -457,10 +457,16 @@ CBox CHyprPill::visibleBoxGlobal() const {
     if (dodging)
         std::tie(resolvedCenter, resolvedWidth) = solveConstrained(resolvedWidth, dodging);
 
-    const int targetW = std::max<int>(1, std::lround(resolvedWidth));
+    int targetW = std::max<int>(1, std::lround(resolvedWidth));
     const int targetH = std::max<int>(1, std::lround(m_height));
-    const int targetX = std::clamp(static_cast<int>(std::lround(resolvedCenter - targetW / 2.F)), static_cast<int>(std::lround(windowLeft)),
-                                   static_cast<int>(std::lround(windowRight - targetW)));
+    int targetX = std::clamp(static_cast<int>(std::lround(resolvedCenter - targetW / 2.F)), static_cast<int>(std::lround(windowLeft)),
+                             static_cast<int>(std::lround(windowRight - targetW)));
+
+    // Keep a dodging pill steady while hovered so repeated clicks don't chase a moving target.
+    if (dodging && m_hovered && m_lastFrameDodging) {
+        targetX = m_lastFrameResolvedX;
+        targetW = m_lastFrameResolvedW;
+    }
 
     m_lastFrameDodging   = dodging;
     m_lastFrameResolvedX = targetX;


### PR DESCRIPTION
### Motivation
- Restore original pointer hover/click responsiveness by undoing the recent input gating/occluder changes that caused pills to stop reacting to pointer events.
- Preserve a single usability fix so dodging pills remain steady while hovered to avoid missed/dodging clicks.

### Description
- Reverted the pointer-input gating and occluder filtering changes and restored prior interaction behavior in the pill codebase.
- Kept a minimal change in `visibleBoxGlobal()` that makes `targetX` and `targetW` mutable and, when a pill is `dodging` and `m_hovered` while the previous frame was dodging, reuses `m_lastFrameResolvedX`/`m_lastFrameResolvedW` to stabilize the pill position while hovered.
- Changes touch the pill geometry/hit logic in `hyprpill/pillDeco.cpp` and restore the header surface to the previous interaction baseline in `hyprpill/pillDeco.hpp`.

### Testing
- Attempted a local build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to missing system package dependencies (`hyprland`, `libdrm`, `libinput`, `libudev`, `pangocairo`, `pixman-1`, `wayland-server`, and `xkbcommon`).
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698edd20a9a883328fe8a5001b4bc457)